### PR TITLE
33 Добавить CORS Middleware на бэкенд

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from .routers import ping, auth, add_sample_task
 
 from logging.config import dictConfig
@@ -9,6 +10,18 @@ dictConfig(LogConfig().dict())
 logger = logging.getLogger('MSE-telegram')
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost",
+        "http://localhost:8080",
+        "http://frontend",
+        "http://frontend:8080"
+    ],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
 app.include_router(ping.router)
 app.include_router(auth.router)
 app.include_router(add_sample_task.router)


### PR DESCRIPTION
Добавлен CORS для FastAPI в соответствии с оффициальной [документацией](https://fastapi.tiangolo.com/tutorial/cors/)