### PR TITLE
Replaced arguments, removed an example

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import os
 from aio_pika import abc
@@ -8,9 +7,7 @@ from logging.config import dictConfig
 import logging
 
 from .queue.queue_manager import QueueManager
-from .routers import ping, auth, add_sample_task
 from .config.log_config import LogConfig
-from .schemas.task import TaskTelegramMessage
 from .routers import ping, auth, add_sample_task, crud
 from .tables import tables_manager
 from .database import init_db
@@ -40,13 +37,6 @@ async def startup_event():
     logger.info('Server started')
     await init_db(str(settings.MONGO_DB_URI), settings.MONGO_DB)
     await QueueManager().create_connection()
-
-    # example of filling queue with tasks
-    for i in range(10):
-        await asyncio.sleep(1)
-        task = TaskTelegramMessage(chat_id="560639281", content=f"hello {i}", params={"1": "1", "2": "2"})
-        await QueueManager().add_task_to_queue(task)
-
     # example subscribe to queue
     await QueueManager().on_update_queue(process_update)
 

--- a/backend/app/routers/add_sample_task.py
+++ b/backend/app/routers/add_sample_task.py
@@ -1,6 +1,6 @@
 from aio_pika import connect, Message
 from fastapi import APIRouter
-from ..schemas.task import TaskInterface
+from ..schemas.task import TaskInterface, TaskTelegramMessage
 from ..config.settings import settings
 
 
@@ -10,7 +10,7 @@ router = APIRouter(
 )
 
 
-async def add_task_to_queue(task: TaskInterface):
+async def add_task_to_queue(task: TaskTelegramMessage):
     connection = await connect(str(settings.RABBIT_URI))
     channel = await connection.channel()
     await channel.default_exchange.publish(Message(
@@ -19,6 +19,6 @@ async def add_task_to_queue(task: TaskInterface):
 
 
 @router.post("/add_sample_task")
-async def add_sample_task(task: TaskInterface):
+async def add_sample_task(task: TaskTelegramMessage):
     await add_task_to_queue(task)
     return {'result': f'Task for {task.chat_id} chat added to queue'}


### PR DESCRIPTION
Изменил аргументы методов add_task_to_queue и add_sample_task на TaskTelegramMessage, а также убрал пустые импорты и пример, выполняемый при запуске контейнера, в котором использовался конкретный id чата.
Для проверки работоспособности можно использовать следующий запрос
```
POST /add_sample_task
{
    "chat_id": "<chat_id>",
    "content": "<content>",
    "params": {
        "param_key": "<param_value>"
    }
}
```