### PR TITLE
134 Неверный id таблицы при удалении

### DIFF
--- a/backend/app/routers/crud.py
+++ b/backend/app/routers/crud.py
@@ -108,7 +108,7 @@ async def delete_table(table_id: PydanticObjectId):
             detail="Table not found"
         )
     await table.delete()
-    TablesManager().delete_table(table.table_id)
+    TablesManager().delete_table(table.id)
     return table
 
 


### PR DESCRIPTION
Баг заключался в том что, пытались удалить по id таблицы из Google, а не по id из DB.