### PR TITLE
139 Изменение startup'а FastAPI

### DIFF
--- a/backend/app/tables/tables_manager.py
+++ b/backend/app/tables/tables_manager.py
@@ -44,3 +44,10 @@ class TablesManager:
         task = self.__tables.pop(id)
         if task:
             task.cancel()
+
+    def shutdown(self):
+        """
+        Remove table tasks from event loop
+        """
+        for task in self.__tables.values():
+            task.cancel()


### PR DESCRIPTION
Использовался утсаревший декоратор FastAPI: @app.on_event("startup"). Сменил его на [Lifespan](https://fastapi.tiangolo.com/advanced/events/#lifespan). Также обноружил утечку, по завершению работы всего приложения задачи из `TablesManager'а` не завершались. Добавил метод `shutdown` в `TablesManager`, который завершает все задачи.